### PR TITLE
Rails 7 Compatibility Patch

### DIFF
--- a/lib/validator/nric/nric_validator.rb
+++ b/lib/validator/nric/nric_validator.rb
@@ -2,7 +2,7 @@ module Validator
   module Nric
     class NricValidator < ActiveModel::EachValidator
       def validate_each(record, attribute, value)
-        record.errors[attribute] << (options[:message] || 'is not an NRIC') \
+        record.errors.add(attribute, options[:message] || 'is not an NRIC') \
           unless Validator::Nric.check(value)
       end
     end


### PR DESCRIPTION
When validating a record on Rails 6.1, we get the following warning due to [changes](https://guides.rubyonrails.org/7_0_release_notes.html#active-model-removals) in `ActiveModel::Errors`: `DEPRECATION WARNING: Calling "<<" to an ActiveModel::Errors message array in order to add an error is deprecated. Please call "ActiveModel::Errors#add" instead`. This PR implements that small change. 